### PR TITLE
ELMU #162 Include username in emails

### DIFF
--- a/src/server/user-controller.js
+++ b/src/server/user-controller.js
@@ -10,7 +10,6 @@ import Database from '../stores/database.js';
 import permissions from '../domain/permissions';
 import UserService from '../services/user-service';
 import MailService from '../services/mail-service';
-import requestHelper from '../utils/request-helper';
 import ClientDataMapper from './client-data-mapper';
 import ServerConfig from '../bootstrap/server-config';
 import UserRequestHandler from './user-request-handler';
@@ -125,33 +124,13 @@ class UserController {
 
     router.post('/api/v1/users', jsonParser, (req, res) => this.userRequestHandler.handlePostUser(req, res));
 
-    router.post('/api/v1/users/request-password-reset', jsonParser, async (req, res) => {
-      const { email } = req.body;
-      const user = await this.userService.getUserByEmailAddress(email);
+    router.post('/api/v1/users/request-password-reset', jsonParser, (req, res) => this.userRequestHandler.handlePostUserPasswordResetRequest(req, res));
 
-      if (user) {
-        const resetRequest = await this.userService.createPasswordResetRequest(user);
-        const { origin } = requestHelper.getHostInfo(req);
-        const resetCompletionLink = urls.concatParts(origin, urls.getCompletePasswordResetUrl(resetRequest._id));
-        await this.mailService.sendPasswordResetRequestCompletionLink(user.email, resetCompletionLink);
-      }
+    router.post('/api/v1/users/complete-password-reset', jsonParser, (req, res) => this.userRequestHandler.handlerPostUserPasswordResetCompletion(req, res));
 
-      return res.send({});
-    });
+    router.post('/api/v1/users/account', [needsAuthentication(), jsonParser], (req, res) => this.userRequestHandler.handlePostUserAccount(req, res));
 
-    router.post('/api/v1/users/complete-password-reset', jsonParser, async (req, res) => {
-      const { passwordResetRequestId, password } = req.body;
-      const user = await this.userService.completePasswordResetRequest(passwordResetRequestId, password);
-      if (!user) {
-        throw new NotFound();
-      }
-
-      return res.send({ user });
-    });
-
-    router.post('/api/v1/users/account', [needsAuthentication(), jsonParser], (req, res) => UserRequestHandler.handlePostUserAccount(req, res));
-
-    router.post('/api/v1/users/profile', [needsAuthentication(), jsonParser], (req, res) => UserRequestHandler.handlePostUserProfile(req, res));
+    router.post('/api/v1/users/profile', [needsAuthentication(), jsonParser], (req, res) => this.userRequestHandler.handlePostUserProfile(req, res));
 
     router.post('/api/v1/users/login', jsonParser, (req, res, next) => {
       passport.authenticate('local', (err, user) => {

--- a/src/services/mail-service.js
+++ b/src/services/mail-service.js
@@ -13,39 +13,69 @@ class MailService {
     this.transport = nodemailer.createTransport(serverConfig.smtpOptions);
   }
 
-  sendRegistrationVerificationLink(emailAddress, verificationLink) {
+  sendRegistrationVerificationLink({ username, email, verificationLink }) {
     logger.info('Creating email with registration verification link %s', verificationLink);
+
+    const germanText
+      = 'Willkommen!\n\n'
+      + `Sie haben sich erfolgreich als ${username} auf ELMU registriert.\n`
+      + `Bitte bestätigen Sie Ihre Registrierung hier: ${verificationLink}`;
+
+    const germanHtml
+      = '<p>Willkommen!<br/><br/>'
+      + `Sie haben sich erfolgreich als ${username} auf ELMU registriert.<br/>`
+      + `Bitte bestätigen Sie Ihre Registrierung hier: <a href="${verificationLink}">Registrierung bestätigen</a></p>`;
+
+    const englishText
+      = 'Welcome!\n\n'
+      + `You have registered successfully with ELMU as ${username}.\n`
+      + `Please confirm your registration here: ${verificationLink}`;
+
+    const englishHtml
+      = '<p>Welcome!<br/><br/>'
+      + `You have registered successfully with ELMU as ${username}.<br/>`
+      + `Please confirm your registration here: <a href="${verificationLink}">confirm registration</a></p>`;
+
     const message = {
       from: ELMU_WEB_EMAIL_ADDRESS,
-      to: emailAddress,
+      to: email,
       subject: 'Willkommen auf ELMU! / Welcome to ELMU!',
-      text: [
-        `Willkommen! Sie haben sich erfolgreich auf ELMU registriert. Bitte bestätigen Sie Ihre Registrierung hier: ${verificationLink}`,
-        `Welcome! You have registered successfully with ELMU. Please confirm your registration here: ${verificationLink}`
-      ].join('\n\n'),
-      html: [
-        `<p>Willkommen! Sie haben sich erfolgreich auf ELMU registriert. Bitte bestätigen Sie Ihre Registrierung hier: <a href="${verificationLink}">Registrierung bestätigen</a></p>`,
-        `<p>Welcome! You have registered successfully with ELMU. Please confirm your registration here: <a href="${verificationLink}">confirm registration</a></p>`
-      ].join('\n')
+      text: `${germanText}\n\n${englishText}`,
+      html: `${germanHtml}\n${englishHtml}`
     };
 
     return this._sendMail(message);
   }
 
-  sendPasswordResetRequestCompletionLink(emailAddress, completionLink) {
+  sendPasswordResetRequestCompletionLink({ username, email, completionLink }) {
     logger.info('Creating email with password reset request completion link %s', completionLink);
+
+    const germanText
+      = `Hallo ${username}!\n\n`
+      + 'Sie möchten Ihr Kennwort auf ELMU ändern?\n'
+      + `Zum Ändern Ihres Kennworts klicken Sie bitte hier: ${completionLink}`;
+
+    const germanHtml
+      = `<p>Hallo ${username}!<br/><br/>`
+      + 'Sie möchten Ihr Kennwort auf ELMU ändern?<br/>'
+      + `Zum Ändern Ihres Kennworts klicken Sie bitte hier: <a href="${completionLink}">Kennwort ändern</a>.</p>`;
+
+    const englishText
+      = `Hello ${username}!\n\n`
+      + 'You want to change your password for ELMU?\n'
+      + `Please click here in order to change your password: ${completionLink}`;
+
+    const englishHtml
+      = `<p>Hello ${username}!<br/><br/>`
+      + 'You want to change your password for ELMU?<br/>'
+      + `Please click here in order to change your password: <a href="${completionLink}">change password</a>.</p>`;
+
     const message = {
       from: ELMU_WEB_EMAIL_ADDRESS,
-      to: emailAddress,
-      subject: 'Ihr Kennwort auf ELMU / Your password for ELMU',
-      text: [
-        `Sie möchten Ihr Kennwort auf ELMU ändern? Zum Ändern Ihres Kennworts klicken Sie bitte hier: ${completionLink}`,
-        `You want to change your password for ELMU? Please click here in order to change your password: ${completionLink}`
-      ].join('\n\n'),
-      html: [
-        `<p>Sie möchten Ihr Kennwort auf ELMU ändern? Zum Ändern Ihres Kennworts klicken Sie bitte hier: <a href="${completionLink}">Kennwort ändern</a>.</p>`,
-        `<p>You want to change your password for ELMU? Please click here in order to change your password: <a href="${completionLink}">change password</a>.</p>`
-      ].join('\n')
+      to: email,
+      subject: 'Ihr Kennwort auf ELMU/ Your password for ELMU',
+      text: `${germanText}\n\n${englishText}`,
+      html: `${germanHtml}\n${englishHtml}`
     };
 
     return this._sendMail(message);


### PR DESCRIPTION
Closes #162 

Looks like this:

Registration email, HTML and Text versions
<img width="509" alt="Screenshot 2021-10-14 at 11 24 00" src="https://user-images.githubusercontent.com/8189923/137295247-9d50821c-c9a4-47ee-b56d-11b6764c2180.png">

<img width="962" alt="Screenshot 2021-10-14 at 11 24 10" src="https://user-images.githubusercontent.com/8189923/137295257-cd9d82b6-669f-48a5-85ba-8e8de45fc2ae.png">


Password reset email, HTML and Text versions

<img width="490" alt="Screenshot 2021-10-14 at 11 24 40" src="https://user-images.githubusercontent.com/8189923/137295318-e52970a0-cd13-40d1-84a3-8fbec3d27408.png">

<img width="1058" alt="Screenshot 2021-10-14 at 11 24 50" src="https://user-images.githubusercontent.com/8189923/137295329-21dd6545-e5e6-4f10-b67a-e379438623d1.png">


