### PR TITLE
ELMU #178 Re-introduce SVG country flag icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "express-joi-validation": "~5.0.0",
     "express-session": "~1.17.2",
     "fast-deep-equal": "~3.1.3",
+    "flag-icon-css": "~3.5.0",
     "format-error": "~1.0.0",
     "glob": "~7.2.0",
     "gravatar": "~1.8.2",

--- a/src/components/localization/country-flag-and-name.js
+++ b/src/components/localization/country-flag-and-name.js
@@ -1,14 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function countryCodeToFlagEmoji(country) {
-  return String.fromCodePoint(...[...country].map(c => c.charCodeAt() + 0x1F1A5));
-}
-
 function CountryFlagAndName({ code, name, flagOnly }) {
   return (
     <span className="CountryFlagAndName">
-      <span>{countryCodeToFlagEmoji(code)}</span>
+      <span className={`flag-icon flag-icon-${code.toLowerCase()}`} title={name} />
       {!flagOnly && <span>&nbsp;&nbsp;{name}</span>}
     </span>
   );

--- a/src/server/static-controller.js
+++ b/src/server/static-controller.js
@@ -11,6 +11,10 @@ const staticConfig = [
     destination: '../../static'
   },
   {
+    root: '/images/flags',
+    destination: '../../node_modules/flag-icon-css/flags'
+  },
+  {
     root: '/fonts/fontawesome',
     destination: '../../node_modules/@fortawesome/fontawesome-free/webfonts'
   }

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -1,6 +1,9 @@
 @import '../../node_modules/antd/dist/antd.less';   // import official less entry file
 @import './ant-overrides.less';                     // override variables here
 
+@import '../../node_modules/flag-icon-css/less/flag-icon.less';
+@flag-icon-css-path: '/images/flags';
+
 @import (less) '../../node_modules/react-piano/dist/styles.css';
 @import (less) '../../node_modules/abcjs/abcjs-midi.css';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4887,6 +4887,11 @@ fined@^1.0.1:
     object.pick "^1.2.0"
     parse-filepath "^1.0.1"
 
+flag-icon-css@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/flag-icon-css/-/flag-icon-css-3.5.0.tgz#430747d5cb91e60babf85494de99173c16dc7cf2"
+  integrity sha512-pgJnJLrtb0tcDgU1fzGaQXmR8h++nXvILJ+r5SmOXaaL/2pocunQo2a8TAXhjQnBpRLPtZ1KCz/TYpqeNuE2ew==
+
 flagged-respawn@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"


### PR DESCRIPTION
Unicode based emojis are not displayed on Windows OS.
Therefore we have to fallback to the solution removed
in #139 using CSS with background images

Closes #178 