### PR TITLE
ELMU-25 Update educandu to v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "private": true,
   "dependencies": {
-    "@educandu/educandu": "0.8.0",
+    "@educandu/educandu": "0.9.0",
     "@educandu/node-jsx-loader": "~2.2.0",
     "parseboolean": "~1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,10 +69,10 @@
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz#c3c5ae543c897caa9c2a68630bed355be5f9990f"
   integrity sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==
 
-"@educandu/educandu@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@educandu/educandu/-/educandu-0.8.0.tgz#3f74f84403f3e1d0f4ffa60974e825cca51b026f"
-  integrity sha512-Oz4B5PI5XF4ZsL+aQNOkpQo4mhAyppR6Lu9es9JQkOWN08/iQuyMA+FJSJXoratHHcv46Dwopdlhiq/ZP+xfpw==
+"@educandu/educandu@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@educandu/educandu/-/educandu-0.9.0.tgz#1bfd9d9c3eb9848988510694f4e501dbdb4138e5"
+  integrity sha512-PrisMA4O0ua4TQ7QZt1Oz52vnN9TA9MAqUxdY/4kLHJHSGGeBAmPoAqVA5lqI80kjcsHtBZisem60Uzvas+Zqw==
   dependencies:
     "@ant-design/icons" "^4.7.0"
     "@educandu/node-jsx-loader" "^2.2.0"


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/ELMU-25

Script `educandu-2021-12-28-01-remove-duplicate-tags.js` ran in 6.668 seconds locally, on a staging dump.