### PR TITLE
ELMU-53 Update educandu to v0.28.0 and keep styling close to before

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "private": true,
   "dependencies": {
-    "@educandu/educandu": "0.27.1",
+    "@educandu/educandu": "0.28.0",
     "@educandu/node-jsx-loader": "~2.2.0",
     "parseboolean": "~1.0.0"
   },

--- a/src/bundles/home-page-template.js
+++ b/src/bundles/home-page-template.js
@@ -30,9 +30,7 @@ function HomePageTemplate({ children, alerts }) {
           </div>
           {children}
           {settings.homepageInfo && (
-            <div className="HomePageTemplate-info">
-              <Markdown renderMedia>{settings.homepageInfo}</Markdown>
-            </div>
+            <Markdown renderMedia>{settings.homepageInfo}</Markdown>
           )}
         </div>
       </main>

--- a/src/bundles/home-page-template.less
+++ b/src/bundles/home-page-template.less
@@ -1,6 +1,3 @@
 .HomePageTemplate-logo {
   margin-bottom: 10px;
 }
-.HomePageTemplate-info {
-  .m-content;
-}

--- a/src/bundles/page-footer.less
+++ b/src/bundles/page-footer.less
@@ -1,10 +1,10 @@
 .PageFooter {
+  .m-page-content;
   flex: none;
   display: flex;
   z-index: 1000;
   align-items: center;
   justify-content: center;
-  padding: @edu-content-padding;
   position: relative;
   z-index: @edu-z-index-base-layer;
 }

--- a/src/bundles/page-header.less
+++ b/src/bundles/page-header.less
@@ -1,5 +1,5 @@
 @page-header-content-min-height: 32px;
-@page-header-min-height: @page-header-content-min-height + (2* @edu-content-padding);
+@page-header-min-height: @page-header-content-min-height + (2* @edu-page-content-padding);
 
 .PageHeader {
   top: 0;
@@ -9,7 +9,7 @@
   z-index: @edu-z-index-cover-layer;
   background-color: @grey-1;
   box-shadow: 0 2px 8px @grey-4;
-  margin-bottom: @edu-content-padding;
+  margin-bottom: @edu-page-content-padding;
 
   &.PageHeader--fullScreen {
     box-shadow: none;
@@ -25,7 +25,8 @@
 
 .PageHeader-headerContent {
   display: block;
-  padding: @edu-content-padding;
+  .m-page-content;
+
 
   &.PageHeader-headerContent--left {
     display: flex;

--- a/src/bundles/page-template.less
+++ b/src/bundles/page-template.less
@@ -10,6 +10,7 @@
 }
 
 .PageTemplate-contentArea {
+  .m-page-content;
   flex: 1 0 0%;
   display: flex;
   align-items: flex-start;

--- a/src/main.less
+++ b/src/main.less
@@ -13,3 +13,4 @@
 @edu-font-family: 'Roboto', sans-serif;
 @edu-primary-color: @blue-7;
 @edu-link-color: @blue-7;
+@edu-page-content-padding: 12px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,10 +371,10 @@
     yaml "^1.10.2"
     yargs "^17.3.1"
 
-"@educandu/educandu@0.27.1":
-  version "0.27.1"
-  resolved "https://registry.yarnpkg.com/@educandu/educandu/-/educandu-0.27.1.tgz#8c2a4b2bba17a38805eb32c2a80c122b46fe3a04"
-  integrity sha512-FMXC4HC4C/F29Wp+Jetxn8GqCvRrOaU6LGm/OOewwemi0drmVVAbb2xIKgS7iNEDfFBwzsQSGoVtCl9zFQ+P0g==
+"@educandu/educandu@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@educandu/educandu/-/educandu-0.28.0.tgz#07953267b896d0f73240a1439121778ff57e080e"
+  integrity sha512-Ilgqa1PXVhooXj6eVSP4kROKMbxPd8vz5ccFGOri3377Tvc4I5zgqfJgEWiAkbpmM3WGdET0UNYRIH4EFLeUOg==
   dependencies:
     "@ant-design/icons" "^4.7.0"
     "@educandu/node-jsx-loader" "^2.2.0"


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/ELMU-53

and looks like

<img width="966" alt="Screen Shot 2022-03-03 at 11 45 26" src="https://user-images.githubusercontent.com/8189923/156549714-0f5f1de5-90a0-442f-a471-3ce614527013.png">

