### PR TITLE
ELMU-70 Update educandu to v0.43.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,6 +33,7 @@ const elmuEnv = {
   ELMU_SESSION_COOKIE_DOMAIN: 'localhost',
   ELMU_SESSION_COOKIE_NAME: 'SESSION_ID_ELMU_LOCAL',
   ELMU_CONSENT_COOKIE_NAME_PREFIX: 'CONSENT_ELMU_LOCAL',
+  ELMU_UPLOAD_LIABILITY_COOKIE_NAME: 'UPLOAD_LIABILITY_ELMU_LOCAL',
   ELMU_EMAIL_SENDER_ADDRESS: 'educandu-test-app@test.com',
   ELMU_SMTP_OPTIONS: 'smtp://127.0.0.1:8025/?ignoreTLS=true',
   ELMU_INITIAL_USER: JSON.stringify({ username: 'test', password: 'test', email: 'test@test.com' }),

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "private": true,
   "dependencies": {
-    "@educandu/educandu": "0.42.0",
+    "@educandu/educandu": "0.43.0",
     "@educandu/node-jsx-loader": "~2.2.0",
     "parseboolean": "~1.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ const config = {
   sessionCookieDomain: processEnv.ELMU_SESSION_COOKIE_DOMAIN,
   sessionCookieName: processEnv.ELMU_SESSION_COOKIE_NAME,
   consentCookieNamePrefix: processEnv.ELMU_CONSENT_COOKIE_NAME_PREFIX,
+  uploadLiabilityCookieName: processEnv.ELMU_UPLOAD_LIABILITY_COOKIE_NAME,
   emailSenderAddress: 'website@elmu.online',
   smtpOptions: smtpOptions.startsWith('smtp://') ? smtpOptions : JSON.parse(smtpOptions),
   initialUser: processEnv.ELMU_INITIAL_USER ? JSON.parse(processEnv.ELMU_INITIAL_USER) : null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,10 +378,10 @@
     yaml "^1.10.2"
     yargs "^17.3.1"
 
-"@educandu/educandu@0.42.0":
-  version "0.42.0"
-  resolved "https://registry.yarnpkg.com/@educandu/educandu/-/educandu-0.42.0.tgz#2d483f6018344e5e60212b26a3965718a9e0c9a8"
-  integrity sha512-oCEqAAyiosRa6OrZOcog18p4T/vicmKLPEdgyOzUO/PhjvnhQthYvp0sm/EYhhMMTCquYJYHs4dZWhbBfdm0Hw==
+"@educandu/educandu@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@educandu/educandu/-/educandu-0.43.0.tgz#1815953b0392eeaa746d7daf5bd8ffa453fd3d55"
+  integrity sha512-RqLL+eSYjg9Ov0S1H7q49T/E9vw8maJjVZ6jz5ixjKFlKhnnKeI0UyLFOLCXxz23aQdRxWzOBGu9x52GwX1D/g==
   dependencies:
     "@ant-design/icons" "^4.7.0"
     "@educandu/node-jsx-loader" "^2.2.0"


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/ELMU-70

Octopus setup:
<img width="1686" alt="Screen Shot 2022-05-24 at 09 12 56" src="https://user-images.githubusercontent.com/8189923/169971186-9bda638c-330c-4669-80bc-437263b4214d.png">
